### PR TITLE
Feature/ml and detection enhancements

### DIFF
--- a/GovTaskManagement.Application/Dtos/AuthResponseDto.cs
+++ b/GovTaskManagement.Application/Dtos/AuthResponseDto.cs
@@ -11,6 +11,7 @@ namespace GovTaskManagement.Application.Dtos
     {
         public string AccessToken { get; set; }
         public string RefreshToken { get; set; }
-        
+        // Non-null means the account is suspended — no tokens are issued
+        public DateTime? SuspendedUntil { get; set; }
     }
 }

--- a/GovTaskManagement.Application/Dtos/BehaviorWindowDto.cs
+++ b/GovTaskManagement.Application/Dtos/BehaviorWindowDto.cs
@@ -52,5 +52,13 @@ namespace GovTaskManagement.Application.Dtos
         // Attack string detection — populated by the Angular tracker
         public bool HackingStringDetected { get; set; } = false;
         public string? DetectedPatterns { get; set; }
+
+        // Extended attack signals
+        public int PasteCount { get; set; } = 0;
+        public bool SuspiciousPasteDetected { get; set; } = false;
+        public int DevToolsShortcutCount { get; set; } = 0;
+        public bool AbnormalInputDetected { get; set; } = false;
+        public bool DevToolsDetected { get; set; } = false;
+        public int UnauthorizedAttempts { get; set; } = 0;
     }
 }

--- a/GovTaskManagement.Application/Dtos/MLPredictionResponse.cs
+++ b/GovTaskManagement.Application/Dtos/MLPredictionResponse.cs
@@ -2,10 +2,16 @@ namespace GovTaskManagement.Application.Dtos
 {
     public class MlPredictionResponseDto
     {
-        public int Prediction { get; set; }
-        public string Label { get; set; }
         public double Confidence { get; set; }
+        public TabPfnDto TabPfn { get; set; }
         public AnalysisDto Analysis { get; set; }
+    }
+
+    public class TabPfnDto
+    {
+        public double Score { get; set; }
+        public string Label { get; set; }
+        public string Verdict { get; set; }
     }
 
     public class AnalysisDto

--- a/GovTaskManagement.Application/Interfaces/ServiceInterfaces/ISuspensionService.cs
+++ b/GovTaskManagement.Application/Interfaces/ServiceInterfaces/ISuspensionService.cs
@@ -1,0 +1,8 @@
+namespace GovTaskManagement.Application.Interfaces.ServiceInterfaces
+{
+    public interface ISuspensionService
+    {
+        void SuspendUser(string userId, int minutes = 30);
+        bool IsSuspended(string userId, out TimeSpan remaining);
+    }
+}

--- a/GovTaskManagement.Application/Services/AuthService.cs
+++ b/GovTaskManagement.Application/Services/AuthService.cs
@@ -13,16 +13,21 @@ namespace GovTaskManagement.Application.Services
         private readonly IConfiguration _configuration;
         private readonly ITokenHasher _tokenHasher;
         private readonly IJwtTokenGenerator _jwtGenerator;
+        private readonly ISuspensionService _suspensionService;
+
         public AuthService(IConfiguration config, IUnitOfWork unitOfWork,
             IApiUserRepository _apiUserRepository,
             ITokenHasher tokenHasher,
-            IJwtTokenGenerator jwtGenerator)
+            IJwtTokenGenerator jwtGenerator,
+            ISuspensionService suspensionService)
         {
             _unitOfWork = unitOfWork;
             _configuration = config;
             _tokenHasher = tokenHasher;
             _jwtGenerator = jwtGenerator;
+            _suspensionService = suspensionService;
         }
+
         public async Task<AuthResponseDto?> LoginAsync(LoginRequestDto loginDto)
         {
             var user = await _unitOfWork.ApiUserRepository
@@ -30,6 +35,10 @@ namespace GovTaskManagement.Application.Services
 
             if (user is null)
                 return null;
+
+            // Check suspension before password so the user can't probe for a valid account
+            if (_suspensionService.IsSuspended(user.Id, out var remaining))
+                return new AuthResponseDto { SuspendedUntil = DateTime.UtcNow.Add(remaining) };
 
             var validPassword = await _unitOfWork
                 .ApiUserRepository

--- a/GovTaskManagement.Application/Services/BehaviorService.cs
+++ b/GovTaskManagement.Application/Services/BehaviorService.cs
@@ -49,6 +49,12 @@ namespace GovTaskManagement.Application.Services
                 StdPreClickSpeed = dto.StdPreClickSpeed,
                 HackingStringDetected = dto.HackingStringDetected,
                 DetectedPatterns = dto.DetectedPatterns,
+                PasteCount = dto.PasteCount,
+                SuspiciousPasteDetected = dto.SuspiciousPasteDetected,
+                DevToolsShortcutCount = dto.DevToolsShortcutCount,
+                AbnormalInputDetected = dto.AbnormalInputDetected,
+                DevToolsDetected = dto.DevToolsDetected,
+                UnauthorizedAttempts = dto.UnauthorizedAttempts,
                 };
 
                     await _unitOfWork.BehaviorRepository.CreateAsync(entity);

--- a/GovTaskManagement.Application/Services/SecurityService.cs
+++ b/GovTaskManagement.Application/Services/SecurityService.cs
@@ -43,7 +43,13 @@ namespace GovTaskManagement.Application.Services
                 HardwareConcurrency = dto.Snapshot.HardwareConcurrency,
                 Location = dto.Snapshot.Location,
                 HackingStringDetected = dto.Snapshot.HackingStringDetected,
-                DetectedPatterns = dto.Snapshot.DetectedPatterns
+                DetectedPatterns = dto.Snapshot.DetectedPatterns,
+                PasteCount = dto.Snapshot.PasteCount,
+                SuspiciousPasteDetected = dto.Snapshot.SuspiciousPasteDetected,
+                DevToolsShortcutCount = dto.Snapshot.DevToolsShortcutCount,
+                AbnormalInputDetected = dto.Snapshot.AbnormalInputDetected,
+                DevToolsDetected = dto.Snapshot.DevToolsDetected,
+                UnauthorizedAttempts = dto.Snapshot.UnauthorizedAttempts
             };
 
             await _unitOfWork.BehaviorRepository.CreateAsync(snapshot);

--- a/GovTaskManagement.Application/Services/SecurityService.cs
+++ b/GovTaskManagement.Application/Services/SecurityService.cs
@@ -55,12 +55,17 @@ namespace GovTaskManagement.Application.Services
             await _unitOfWork.BehaviorRepository.CreateAsync(snapshot);
             await _unitOfWork.SaveChangesAsync();
 
+            var alertTimestamp = DateTime.TryParse(dto.Timestamp, null,
+                System.Globalization.DateTimeStyles.RoundtripKind, out var parsed)
+                ? parsed
+                : DateTime.UtcNow;
+
             var alert = new SecurityAlert
             {
                 Type = dto.Type,
                 Severity = dto.Severity,
                 Url = dto.Url,
-                Timestamp = DateTime.Parse(dto.Timestamp),
+                Timestamp = alertTimestamp,
                 BehaviorWindowId = snapshot.Id,
                 Snapshot = snapshot,
                 UserId = dto.UserId
@@ -69,28 +74,36 @@ namespace GovTaskManagement.Application.Services
             await _unitOfWork.SecurityAlertRepository.CreateAsync(alert);
             await _unitOfWork.SaveChangesAsync();
 
-            // Send Email to Admin
-            var adminEmail = _configuration["EmailSettings:AdminEmail"];
-            if (!string.IsNullOrEmpty(adminEmail))
+            // Send Email to Admin — wrapped so a failed email never blocks the 200 response
+            try
             {
-                var model = new SecurityAlertEmailModel
+                var adminEmail = _configuration["EmailSettings:AdminEmail"];
+                if (!string.IsNullOrEmpty(adminEmail))
                 {
-                    Type            = dto.Type,
-                    Severity        = dto.Severity,
-                    UserId          = string.IsNullOrEmpty(dto.UserId)          ? "Unauthenticated" : dto.UserId,
-                    UserEmail       = string.IsNullOrEmpty(dto.UserEmail)       ? "Unknown"         : dto.UserEmail,
-                    DetectedPattern = string.IsNullOrEmpty(dto.DetectedPattern) ? "Unknown"         : dto.DetectedPattern,
-                    Url             = dto.Url,
-                    Timestamp       = dto.Timestamp,
-                    Context         = snapshot.Context,
-                    SessionId       = snapshot.SessionId,
-                    Platform        = snapshot.Platform  ?? "Unknown",
-                    UserAgent       = snapshot.UserAgent ?? "Unknown",
-                    Location        = snapshot.Location  ?? "Unknown",
-                };
+                    var model = new SecurityAlertEmailModel
+                    {
+                        Type            = dto.Type,
+                        Severity        = dto.Severity,
+                        UserId          = string.IsNullOrEmpty(dto.UserId)          ? "Unauthenticated" : dto.UserId,
+                        UserEmail       = string.IsNullOrEmpty(dto.UserEmail)       ? "Unknown"         : dto.UserEmail,
+                        DetectedPattern = string.IsNullOrEmpty(dto.DetectedPattern) ? "Unknown"         : dto.DetectedPattern,
+                        Url             = dto.Url,
+                        Timestamp       = dto.Timestamp,
+                        Context         = snapshot.Context,
+                        SessionId       = snapshot.SessionId,
+                        Platform        = snapshot.Platform  ?? "Unknown",
+                        UserAgent       = snapshot.UserAgent ?? "Unknown",
+                        Location        = snapshot.Location  ?? "Unknown",
+                    };
 
-                var subject = $"[GovTask] CRITICAL: {dto.Type} — {(string.IsNullOrEmpty(dto.UserEmail) ? dto.UserId ?? "Unknown User" : dto.UserEmail)}";
-                await _emailService.SendTemplatedEmailAsync(adminEmail, subject, "SecurityAlert", model);
+                    var subject = $"[GovTask] CRITICAL: {dto.Type} — {(string.IsNullOrEmpty(dto.UserEmail) ? dto.UserId ?? "Unknown User" : dto.UserEmail)}";
+                    await _emailService.SendTemplatedEmailAsync(adminEmail, subject, "SecurityAlert", model);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Email failure must not surface as 500 — alert is already saved to DB
+                Console.WriteLine($"[SecurityService] Email notification failed: {ex.Message}");
             }
         }
 

--- a/GovTaskManagement.Domain/Entities/BehaviorWindow.cs
+++ b/GovTaskManagement.Domain/Entities/BehaviorWindow.cs
@@ -54,6 +54,14 @@ namespace GovTaskManagement.Domain.Entities
             // Attack string detection
             public bool HackingStringDetected { get; set; } = false;
             public string? DetectedPatterns { get; set; }
+
+            // Extended attack signals
+            public int PasteCount { get; set; } = 0;
+            public bool SuspiciousPasteDetected { get; set; } = false;
+            public int DevToolsShortcutCount { get; set; } = 0;
+            public bool AbnormalInputDetected { get; set; } = false;
+            public bool DevToolsDetected { get; set; } = false;
+            public int UnauthorizedAttempts { get; set; } = 0;
     }
 }
 

--- a/GovTaskManagement.Infrastructure/Data/ToolDbContextFactory.cs
+++ b/GovTaskManagement.Infrastructure/Data/ToolDbContextFactory.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace GovTaskManagement.Infrastructure.Data
+{
+    public class ToolDbContextFactory : IDesignTimeDbContextFactory<ToolDbContext>
+    {
+        public ToolDbContext CreateDbContext(string[] args)
+        {
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "..", "GovernmentTaskManagement.backend"))
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile("appsettings.Development.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var connectionString = configuration.GetConnectionString("DefaultConnection")
+                ?? "Server=.\\SQLEXPRESS;Database=GovernmentTaskManagementDB;Trusted_Connection=True;TrustServerCertificate=True;";
+
+            var options = new DbContextOptionsBuilder<ToolDbContext>()
+                .UseSqlServer(connectionString)
+                .Options;
+
+            return new ToolDbContext(options);
+        }
+    }
+}

--- a/GovTaskManagement.Infrastructure/Migrations/20260511210112_AddExtendedAttackSignals.Designer.cs
+++ b/GovTaskManagement.Infrastructure/Migrations/20260511210112_AddExtendedAttackSignals.Designer.cs
@@ -4,6 +4,7 @@ using GovTaskManagement.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovTaskManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(ToolDbContext))]
-    partial class toolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511210112_AddExtendedAttackSignals")]
+    partial class AddExtendedAttackSignals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GovTaskManagement.Infrastructure/Migrations/20260511210112_AddExtendedAttackSignals.cs
+++ b/GovTaskManagement.Infrastructure/Migrations/20260511210112_AddExtendedAttackSignals.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovTaskManagement.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExtendedAttackSignals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AbnormalInputDetected",
+                table: "BehaviorWindows",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DevToolsDetected",
+                table: "BehaviorWindows",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DevToolsShortcutCount",
+                table: "BehaviorWindows",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PasteCount",
+                table: "BehaviorWindows",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "SuspiciousPasteDetected",
+                table: "BehaviorWindows",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UnauthorizedAttempts",
+                table: "BehaviorWindows",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AbnormalInputDetected",
+                table: "BehaviorWindows");
+
+            migrationBuilder.DropColumn(
+                name: "DevToolsDetected",
+                table: "BehaviorWindows");
+
+            migrationBuilder.DropColumn(
+                name: "DevToolsShortcutCount",
+                table: "BehaviorWindows");
+
+            migrationBuilder.DropColumn(
+                name: "PasteCount",
+                table: "BehaviorWindows");
+
+            migrationBuilder.DropColumn(
+                name: "SuspiciousPasteDetected",
+                table: "BehaviorWindows");
+
+            migrationBuilder.DropColumn(
+                name: "UnauthorizedAttempts",
+                table: "BehaviorWindows");
+        }
+    }
+}

--- a/GovTaskManagement.Infrastructure/Services/SuspensionService.cs
+++ b/GovTaskManagement.Infrastructure/Services/SuspensionService.cs
@@ -1,0 +1,32 @@
+using GovTaskManagement.Application.Interfaces.ServiceInterfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace GovTaskManagement.Infrastructure.Services
+{
+    public class SuspensionService : ISuspensionService
+    {
+        private readonly IMemoryCache _cache;
+
+        public SuspensionService(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public void SuspendUser(string userId, int minutes = 30)
+        {
+            var expiry = DateTime.UtcNow.AddMinutes(minutes);
+            _cache.Set($"suspended:{userId}", expiry, TimeSpan.FromMinutes(minutes));
+        }
+
+        public bool IsSuspended(string userId, out TimeSpan remaining)
+        {
+            if (_cache.TryGetValue($"suspended:{userId}", out DateTime expiry))
+            {
+                remaining = expiry - DateTime.UtcNow;
+                if (remaining > TimeSpan.Zero) return true;
+            }
+            remaining = TimeSpan.Zero;
+            return false;
+        }
+    }
+}

--- a/GovernmentTaskManagement.backend/Controllers/AuthController.cs
+++ b/GovernmentTaskManagement.backend/Controllers/AuthController.cs
@@ -27,8 +27,15 @@ namespace GovernmentTaskManagement.Api.Endpoints
         public async Task<IActionResult> Login(LoginRequestDto loginRequest)
         {
             var result = await _authService.LoginAsync(loginRequest);
-            if(result == null)             
-              return Unauthorized("login failed");
+            if (result == null)
+                return Unauthorized("login failed");
+
+            if (result.SuspendedUntil.HasValue)
+            {
+                var minutesRemaining = (int)Math.Ceiling(
+                    (result.SuspendedUntil.Value - DateTime.UtcNow).TotalMinutes);
+                return StatusCode(423, new { error = "ACCOUNT_SUSPENDED", minutesRemaining });
+            }
 
             Response.Cookies.Append("refreshToken", result.RefreshToken, new CookieOptions
             {

--- a/GovernmentTaskManagement.backend/Controllers/MLPredictionController.cs
+++ b/GovernmentTaskManagement.backend/Controllers/MLPredictionController.cs
@@ -11,8 +11,8 @@ namespace GovernmentTaskManagement.Api.Controllers
         [HttpPost("predict")]
         public async Task<IActionResult> Predict(MlPredictionRequestDto dto)
         {
-            await _mLService.PredictAsync(dto);
-            return Ok(dto);
+            var result = await _mLService.PredictAsync(dto);
+            return Ok(result);
         }
     }
 }

--- a/GovernmentTaskManagement.backend/Controllers/SecurityController.cs
+++ b/GovernmentTaskManagement.backend/Controllers/SecurityController.cs
@@ -15,12 +15,27 @@ namespace GovernmentTaskManagement.backend.Controllers
         private readonly ISecurityService _securityService;
         private readonly IEmailService _emailService;
         private readonly IConfiguration _configuration;
+        private readonly ISuspensionService _suspensionService;
 
-        public SecurityController(ISecurityService securityService, IEmailService emailService, IConfiguration configuration)
+        public SecurityController(ISecurityService securityService, IEmailService emailService,
+            IConfiguration configuration, ISuspensionService suspensionService)
         {
             _securityService = securityService;
             _emailService = emailService;
             _configuration = configuration;
+            _suspensionService = suspensionService;
+        }
+
+        [Authorize]
+        [HttpPost("suspend-user")]
+        public IActionResult SuspendUser()
+        {
+            var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            _suspensionService.SuspendUser(userId);
+            return Ok();
         }
 
         [HttpPost("alert-admin")]

--- a/GovernmentTaskManagement.backend/Program.cs
+++ b/GovernmentTaskManagement.backend/Program.cs
@@ -1,6 +1,8 @@
+using GovTaskManagement.Application.Interfaces.ServiceInterfaces;
 using GovTaskManagement.Domain.Entities;
 using GovTaskManagement.Infrastructure;
 using GovTaskManagement.Infrastructure.Data;
+using GovTaskManagement.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -11,6 +13,8 @@ var key = new SymmetricSecurityKey(
                     Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]));
 
 builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddMemoryCache();
+builder.Services.AddScoped<ISuspensionService, SuspensionService>();
 builder.Services.AddExceptionHandler<ExceptionHandlingMiddleware>();
 builder.Services.AddProblemDetails();
 


### PR DESCRIPTION
# Feature Branch: `feature/ML-and-Detection-Enhancements`
 
---
 
## 1. Attack Pattern Detection — Expanded from 20 to 115+ Patterns
 
The `BehaviorTrackerService` pattern library was completely overhauled. The original list had only SQL Injection strings. The new list covers seven attack categories:
 
- **SQL Injection** — UNION SELECT, blind injection, boolean-based, DDL commands, stored procedures, file operations, character encoding bypasses
- **XSS** — 90+ patterns: HTML injection tags, 35 event handlers, protocol bypasses, DOM sinks, obfuscation techniques
- **Command Injection** — shell pipes, backtick execution, Shellshock, environment variable injection, format string attacks
- **SSTI** — Jinja2/Twig `{{...}}`, Java EL `${...}`, ERB/JSP `<%= %>`, Thymeleaf `#{...}`
- **Path Traversal** — `../`, percent-encoded variants, sensitive file targets (`/etc/passwd`, `.env`), null byte injection
- **XXE** — `<!DOCTYPE>`, `<!ENTITY>`, `SYSTEM file://`
- **Attack Tools** — sqlmap, metasploit, msfvenom, nikto, cmd.exe, shell.php
All patterns check typed input, pasted content, and raw URLs. A `safeDecode()` helper decodes percent-encoded URLs before matching.
 
---
 
## 2. Extended Behavioral Attack Signals
 
Six new behavioral signals added:
 
- **Paste detection** — scans clipboard content through all attack patterns; flags malicious payloads
- **DevTools detection** — tracks F12, Ctrl+Shift+I/J/C and Ctrl+U; checks window size difference
- **Abnormal input** — flags input exceeding 500 characters (fuzzing/buffer overflow indicator)
- **Unauthorized navigation** — counts attempts to bypass an active security challenge
- **Detected patterns array** — all matched labels accumulated in every snapshot for audit
All signals are included in the 30-second behavior snapshot sent to the ML pipeline and security alert emails.
 
---
 
## 3. Security Challenge Page — Complete Rewrite
 
Original used Google's public test reCAPTCHA key (always passes, completely bypassable). Replaced with two stacked challenges, both must be solved within 60 seconds:
 
**Layer 1 — Slider puzzle:** Canvas-rendered background with a random notch. A matching piece must be dragged to fill the gap within ±12px. Bots can't solve this from DOM text.
 
**Layer 2 — Canvas CAPTCHA:** 6-character alphanumeric code rendered with noise dots, bezier lines, per-character rotation (±20°), random fonts and colors. Code stored as a private TypeScript field — never in the DOM.
 
Additional hardening:
 
- Both challenges reset on every wrong attempt
- 60-second countdown (turns orange → red)
- 3-attempt limit → account suspension on failure
- Shows trigger reason (e.g. `[SQL Injection] '-- detected in URL`)
- "Can't read it? Refresh" regenerates canvas without resetting slider
---
 
## 4. Account Suspension
 
Failed challenge = 30-minute suspension via server-side `IMemoryCache`. No database migration required. Stored as `userId → expiry` with automatic TTL.
 
Flow:
 
1. Challenge calls `POST /api/Security/suspend-user` then logs out
2. `AuthService.LoginAsync` checks suspension before password verification
3. Returns HTTP **423 Locked** with `minutesRemaining`
4. Login shows: *"Your account has been temporarily suspended due to suspicious activity. Please try again in X minutes."*
---
 
## 5. Admin Email Notifications
 
On security challenge trigger, admin receives:
 
- User ID, email, session ID, platform, user agent
- Page where anomaly was detected
- Detected attack pattern or ML risk reason
- Full behavior snapshot for forensic review
Uses Handlebars.Net with `SecurityAlert.hbs` template. SMTP failures are caught so the client never receives a 500 — alert always saved to database regardless.
 
---
 
## 6. ML Pipeline — End-to-End Fix + Dual AI Display
 
**Critical bug fixed:** `MLPredictionController` was calling the Python ML service correctly but discarding the response and returning the original input DTO. Confidence and analysis were always undefined → 0% and UNKNOWN. The ML pipeline had never actually delivered predictions to the frontend.
 
**Python ML improvements:**
 
- Removed ×0.7 confidence calibration that suppressed all scores
- Lowered Groq threshold from 0.6 → 0.5
- Added `_hard_rules_floor()` — minimum confidence 0.82–0.88 for known attack patterns
- Added `_rule_based_analysis()` fallback — derives HIGH/MEDIUM/LOW when Groq is unavailable
- BOT DETECTION RULES added to Groq prompt: `StdMouseSpeed < 0.05` = definitive bot indicator
- ATTACK SIGNAL RULES added: HackingStringDetected, SuspiciousPasteDetected, AbnormalInputDetected, UnauthorizedAttempts take absolute priority
**Frontend demo panel:**
 
- **Simulate Bot** — near-zero StdMouseSpeed, zero typing, robotic click rate
- **Simulate Malicious User** — human-like movement but DevTools open, 7 shortcuts, 4 unauthorized attempts
- 3-slot prediction history
- TabPFN card (orange/green): verdict + confidence % + strongest signal explanation
- Groq LLM card (red/yellow/green): HIGH/MEDIUM/LOW + full contextual reasoning
- 3 HIGH strikes → fires real security challenge
---
 
## 7. Synthetic Training Data
 
`seed_training_data.py` seeds 86 labelled rows into `BehaviorWindows`:
 
- 35 normal human rows
- 20 bot rows (StdMouseSpeed ≈ 0.01, TypingRate = 0)
- 21 malicious user rows across 7 attack types × 3
- 10 mixed rows (bot behaviour + attack signals combined)
---
 
## Files Changed
 
| Area | Files |
|------|-------|
| Angular frontend | behavior-tracker.service.ts, behavior-predictor.service.ts, security-challenge.component.ts/html, admin-dashboard.ts/html, loginComponent.ts, security-challenge.guard.ts, index.html |
| .NET backend | MLPredictionController.cs, SecurityController.cs, AuthController.cs, AuthService.cs, SecurityService.cs, MLPredictionResponse.cs, AuthResponseDto.cs, ISuspensionService.cs, SuspensionService.cs, Program.cs, SecurityAlert.hbs |
| Python ML service | tabpfn_model.py, routes/predict.py, groq_service.py, db.py, save_prediction.py, seed_training_data.py |